### PR TITLE
Proposed changes to the documentation for the linux running

### DIFF
--- a/tcMenuGenerator/install_linux.sh
+++ b/tcMenuGenerator/install_linux.sh
@@ -25,8 +25,6 @@ fi
 
 if [[ ! -d target/jfx/deps ]] ; then
   echo "Application doesn't appear to be compiled. Attempting to do so (requires jdk, maven)."
-  mvn clean install -f ../baseInputDisplayPlugin
-  mvn clean install -f ../dfRobotCodePlugin
   mvn -DskipTests clean install
   if [[ ! -d target/jfx/deps ]] ; then
     "Compilation failed. Ensure java development kit and maven build system are installed."
@@ -40,7 +38,6 @@ mkdir -p "${BINDIR}"
 
 # Copy jars to destination directory
 cp target/jfx/deps/* "${LIBDIR}/${DIRNAME}/"
-cp -r target/jfx/app/plugins "${LIBDIR}/${DIRNAME}/"
 
 # Make a "binary" script to run the application
 cat > "${BINDIR}/${BINNAME}" << ENDHEREDOC

--- a/tcMenuGenerator/run-on-linux.md
+++ b/tcMenuGenerator/run-on-linux.md
@@ -55,9 +55,8 @@ Run the `install_linux.sh` script in the `tcMenu/tcMenuGenerator` directory. Usi
     cd tcMenuGenerator/target/jfx/app/
     java --module-path ../deps --add-modules com.thecoderscorner.tcmenu.menuEditorUI com.thecoderscorner.menu.editorui.MenuEditorApp
 
-### If you don't want to use plugin automatic updates
+### If you don't want to use Library Manager or Plugin automatic updates
 
-By default the plugin manager will keep the plugins up to date, using a cache of the latest released plugins at thecoderscorner.com. If you are not happy with this, you can either copy the two directories `core-display` and `core-remote` from https://github.com/davetcc/tcMenu/tree/master/CoreXmlPlugins into .tcmenu/plugins. Even if you do this manually, the plugin manager will warn you when they are no longer current.
+By default the plugin manager will keep the plugins up to date, using a cache of the latest released plugins at thecoderscorner.com. If you are not happy with this, you can either copy the two directories `core-display` and `core-remote` from https://github.com/davetcc/tcMenu/tree/master/CoreXmlPlugins into .tcmenu/plugins (or even create a new plugin directory and add the following VM argument -DadditionalPluginsDir=myPath). Even if you do this manually, the plugin manager will warn you when they are no longer current.
 
-
-
+If you do not want to use your Arduino IDE library manager, the embedded folder contains links to the embedded libraries and is  generally quite up to date. You can copy those into your library folder. We really recommend using Library Manager.

--- a/tcMenuGenerator/run-on-linux.md
+++ b/tcMenuGenerator/run-on-linux.md
@@ -6,53 +6,38 @@ Thanks to @ptapping for the linux instructions and build script. *Please note th
 
 At the moment on Linux, in order to run designer on Linux, you'll need to build it first. Then you can run TcMenu designer, you'll need:
 
-* An installation of Java OpenJDK **14** that can be readily installed from your package manager.
+* An installation of Java OpenJDK **11** or later that can be readily installed from your package manager.
 * An installation of maven, that again can be readily installed from your package manager.
 
-We'll look into building a JAR file as part of 1.4.1 so that you won't need to install maven to build it, you'll just need OpenJDK 14 so that you can run it. 
+We'll look into building a package in the future as time permits.
 
 ### Using the build script
 
 Run the `install_linux.sh` script in the `tcMenu/tcMenuGenerator` directory. Using the `--uninstall` option will remove the installed package. The script will tell you where the app has been installed. Take a look through the scripts before running to ensure you're happy with where it will place the files. 
 
-### Raw instructions, example for building 1.4.1 and above.
+### Raw instructions, example for building 1.4.2 and above.
 
     # Ensure java and maven build system installed
     # Arch Linux
-    sudo pacman -Sy jdk14-openjdk maven
+    sudo pacman -Sy jdk11-openjdk maven # or sudo pacman -Sy jdk14-openjdk maven
     # Java version can be selected with
-    # sudo archlinux-java set java-14-openjdk
+    # sudo archlinux-java set <java-11-openjdk or java-14-openjdk>
 
     # Ubuntu, Debian (untested, should work)
-    sudo apt update && sudo apt install openjdk-11-jdk maven
+    sudo apt update && sudo apt install openjdk-11-jdk maven # or use 14 if you wish
     # Java version can be managed with
     # sudo update-alternatives --config java
 
     # Get source code
-    wget https://github.com/davetcc/tcMenu/archive/1.4.1.tar.gz
-    tar xvf 1.4.1.tar.gz
-    cd tcMenu-1.4.1
+    wget https://github.com/davetcc/tcMenu/archive/1.4.2.tar.gz
+    tar xvf 1.4.2.tar.gz
+    cd tcMenu-1.4.2
 
     # Build app
     mvn -DskipTests clean install -f tcMenuGenerator/pom.xml
 
     # Run
     cd tcMenuGenerator/target/jfx/app
-    java --module-path ../deps --add-modules com.thecoderscorner.tcmenu.menuEditorUI com.thecoderscorner.menu.editorui.MenuEditorApp
-
-### Let's say you wanted master instead of a release
-
-    # Get source code for master
-    # Could use --recursive to get submodules, but 1.4.0 doesn't allow installation of them anymore
-    git clone https://github.com/davetcc/tcMenu.git
-    cd tcMenu
-    git checkout master
-
-    # Build app
-    mvn -DskipTests clean install -f tcMenuGenerator
-
-    # Run
-    cd tcMenuGenerator/target/jfx/app/
     java --module-path ../deps --add-modules com.thecoderscorner.tcmenu.menuEditorUI com.thecoderscorner.menu.editorui.MenuEditorApp
 
 ### If you don't want to use Library Manager or Plugin automatic updates

--- a/tcMenuGenerator/run-on-linux.md
+++ b/tcMenuGenerator/run-on-linux.md
@@ -2,17 +2,26 @@
 
 Thanks to @ptapping for the linux instructions and build script. *Please note that running on Linux is supported on a best efforts community basis, as we don't have a desktop Linux build to test with.*
 
+### Things that are needed in order to run and work with TcMenuDesigner.
+
+At the moment on Linux, in order to run designer on Linux, you'll need to build it first. Then you can run TcMenu designer, you'll need:
+
+* An installation of Java OpenJDK **14** that can be readily installed from your package manager.
+* An installation of maven, that again can be readily installed from your package manager.
+
+We'll look into building a JAR file as part of 1.4.1 so that you won't need to install maven to build it, you'll just need OpenJDK 14 so that you can run it. 
+
 ### Using the build script
 
 Run the `install_linux.sh` script in the `tcMenu/tcMenuGenerator` directory. Using the `--uninstall` option will remove the installed package. The script will tell you where the app has been installed. Take a look through the scripts before running to ensure you're happy with where it will place the files. 
 
-### Raw instructions
+### Raw instructions, example for building 1.4.1 and above.
 
     # Ensure java and maven build system installed
     # Arch Linux
-    sudo pacman -Sy jdk11-openjdk maven
+    sudo pacman -Sy jdk14-openjdk maven
     # Java version can be selected with
-    # sudo archlinux-java set java-11-openjdk
+    # sudo archlinux-java set java-14-openjdk
 
     # Ubuntu, Debian (untested, should work)
     sudo apt update && sudo apt install openjdk-11-jdk maven
@@ -20,44 +29,24 @@ Run the `install_linux.sh` script in the `tcMenu/tcMenuGenerator` directory. Usi
     # sudo update-alternatives --config java
 
     # Get source code
-    wget https://github.com/davetcc/tcMenu/archive/1.3.5.tar.gz
-    tar xvf 1.3.5.tar.gz
-    cd tcMenu-1.3.5
-
-    # Build plugins
-    mvn clean install -f baseInputDisplayPlugin/pom.xml
-    mvn clean install -f dfRobotCodePlugin/pom.xml
+    wget https://github.com/davetcc/tcMenu/archive/1.4.1.tar.gz
+    tar xvf 1.4.1.tar.gz
+    cd tcMenu-1.4.1
 
     # Build app
     mvn -DskipTests clean install -f tcMenuGenerator/pom.xml
 
     # Run
-    cd tcMenuGenerator/target/jfx/app/
+    cd tcMenuGenerator/target/jfx/app
     java --module-path ../deps --add-modules com.thecoderscorner.tcmenu.menuEditorUI com.thecoderscorner.menu.editorui.MenuEditorApp
-    
-Another example for 1.4.0
 
-    # Ensure java and maven build system installed
-    # Arch Linux
-    sudo pacman -Sy jdk11-openjdk maven
-    # Java version can be selected with
-    # sudo archlinux-java set java-11-openjdk
+### Let's say you wanted master instead of a release
 
-    # Ubuntu, Debian (untested, should work)
-    sudo apt update && sudo apt install openjdk-11-jdk maven
-    # Java version can be managed with
-    # sudo update-alternatives --config java
-
-    # Get source code for 1.4.0
+    # Get source code for master
     # Could use --recursive to get submodules, but 1.4.0 doesn't allow installation of them anymore
     git clone https://github.com/davetcc/tcMenu.git
     cd tcMenu
-    git checkout 9c502b0
-    git switch -c 1.4.0
-
-    # Build plugins
-    mvn clean install -f baseInputDisplayPlugin
-    mvn clean install -f dfRobotCodePlugin
+    git checkout master
 
     # Build app
     mvn -DskipTests clean install -f tcMenuGenerator
@@ -65,3 +54,10 @@ Another example for 1.4.0
     # Run
     cd tcMenuGenerator/target/jfx/app/
     java --module-path ../deps --add-modules com.thecoderscorner.tcmenu.menuEditorUI com.thecoderscorner.menu.editorui.MenuEditorApp
+
+### If you don't want to use plugin automatic updates
+
+By default the plugin manager will keep the plugins up to date, using a cache of the latest released plugins at thecoderscorner.com. If you are not happy with this, you can either copy the two directories `core-display` and `core-remote` from https://github.com/davetcc/tcMenu/tree/master/CoreXmlPlugins into .tcmenu/plugins. Even if you do this manually, the plugin manager will warn you when they are no longer current.
+
+
+


### PR DESCRIPTION
This PR is proposed changes that make it clearer what's needed after version 1.4.1. this version removes the requirement on executable JAR file plugins and instead uses an XML description file for each plug-in.