### PR TITLE
Update Java/JavaFX dependencies

### DIFF
--- a/embedCONTROLCore/pom.xml
+++ b/embedCONTROLCore/pom.xml
@@ -74,19 +74,28 @@
             <artifactId>jSerialComm</artifactId>
             <version>${jserialcomm.version}</version>
         </dependency>
-        <!-- If you're not running with a JDK including OpenJFX such as  bell-soft full JDK then add these back -->
-        <!--dependency>
+
+        <!--
+        !!!!!!!JavaFX - Special notes!!!!!!
+        If you are using BellSoft's Liberica Full JDK leave the below scopes set to "test"
+        If you are using another JDK without JavaFX, comment out the scope for each org.openjfx component.
+         -->
+
+        <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
             <version>${jfx.version}</version>
-            <scope>compile</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
             <version>${jfx.version}</version>
-            <scope>compile</scope>
-        </dependency-->
+            <scope>test</scope>
+        </dependency>
+
+        <!-- END JavaFX notes -->
+        
     </dependencies>
 
     <build>

--- a/embedCONTROLCore/pom.xml
+++ b/embedCONTROLCore/pom.xml
@@ -50,7 +50,8 @@
     </scm>
 
     <properties>
-        <jfx.version>17.0.0.1</jfx.version>
+        <jdk.version>20</jdk.version>
+        <jfx.version>20</jfx.version>
         <gson.version>2.8.6</gson.version>
         <jserialcomm.version>2.9.2</jserialcomm.version>
         <google.gson.version>2.9.0</google.gson.version>
@@ -96,8 +97,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/embedCONTROLFx/pom.xml
+++ b/embedCONTROLFx/pom.xml
@@ -33,20 +33,27 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- javafx - when not using bellsoft or manually including Open JFX include the below -->
+        <!--
+        !!!!!!!JavaFX - Special notes!!!!!!
+        If you are using BellSoft's Liberica Full JDK leave the below scopes set to "test"
+        If you are using another JDK without JavaFX, comment out the scope for each org.openjfx component.
+         -->
 
-        <!--dependency>
+        <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
             <version>${jfx.version}</version>
-            <scope>compile</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
             <version>${jfx.version}</version>
-            <scope>compile</scope>
-        </dependency-->
+            <scope>test</scope>
+        </dependency>
+
+        <!-- END JavaFX notes -->
+        
     </dependencies>
 
     <build>

--- a/embedCONTROLFx/pom.xml
+++ b/embedCONTROLFx/pom.xml
@@ -14,8 +14,8 @@
     <version>3.2.0-BETA</version>
 
     <properties>
-        <jdk.version>17</jdk.version>
-        <jfx.version>17.0.0.1</jfx.version>
+        <jdk.version>20</jdk.version>
+        <jfx.version>20</jfx.version>
         <jmetro.version>11.6.15</jmetro.version>
     </properties>
 
@@ -73,8 +73,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/embeddedJavaExample/pom.xml
+++ b/embeddedJavaExample/pom.xml
@@ -36,23 +36,34 @@
             <artifactId>embedCONTROLCore</artifactId>
             <version>${tcmenu.api.version}</version>
         </dependency>
+
+        <!--
+        !!!!!!!JavaFX - Special notes!!!!!!
+        If you are using BellSoft's Liberica Full JDK leave the below scopes set to "test"
+        If you are using another JDK without JavaFX, comment out the scope for each org.openjfx component.
+         -->
+
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
             <version>${jfx.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
             <version>${jfx.version}</version>
+            <scope>test</scope>
         </dependency>
 
+        <!-- END JavaFX notes -->
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
             <version>10.0.14</version>
         </dependency>
+
         <!-- To run javax.websocket in embedded server -->
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>

--- a/embeddedJavaExample/pom.xml
+++ b/embeddedJavaExample/pom.xml
@@ -7,9 +7,9 @@
     <version>0.0.1-SNAPSHOT</version>
 
     <properties>
-        <jdk.version>17</jdk.version>
+        <jdk.version>20</jdk.version>
+        <jfx.version>20</jfx.version>
         <jserialcomm.version>2.9.2</jserialcomm.version>
-        <jfx.version>17.0.0.1</jfx.version>
         <tcmenu.api.version>3.2.0-BETA</tcmenu.api.version>
         <springframework.version>5.3.23</springframework.version>
         <timestamp>${maven.build.timestamp}</timestamp>

--- a/tcMenuGenerator/pom.xml
+++ b/tcMenuGenerator/pom.xml
@@ -19,7 +19,7 @@
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
 
         <!-- production deps -->
-        <jdk.version>17</jdk.version>
+        <jdk.version>20</jdk.version>
         <jfx.version>20</jfx.version>
         <jmetro.version>11.6.16</jmetro.version>
         <google.gson.version>2.9.0</google.gson.version>

--- a/tcMenuJavaApi/pom.xml
+++ b/tcMenuJavaApi/pom.xml
@@ -49,8 +49,8 @@
     </distributionManagement>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
+        <jdk.version>20</jdk.version>
+        <jfx.version>20</jfx.version>
         <junit5.surefire.version>1.3.2</junit5.surefire.version>
         <junit5.version>5.9.0</junit5.version>
         <mockito.version>4.8.0</mockito.version>
@@ -144,8 +144,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/zMedia/tcmenu-java-local-dev.md
+++ b/zMedia/tcmenu-java-local-dev.md
@@ -5,7 +5,7 @@ This guide is aimed at developers wanting to build the UI locally within an IDE.
 ## Required Components
 
 * Java 20 OpenJDK runtime, you can use any that you wish. IMPORTANT you must use at least V20.
-* OpenJFX, normally included from maven, if you don't use Liberica Full JDK, then you will need to adjust the designer pom.xml to bring in OpenJFX. See comment in pom.xml.
+* OpenJFX, normally included from maven, if you don't use Liberica Full JDK, then you will need to adjust the designer pom.xml to bring in OpenJFX. See comments in pom.xml of each module.
 * IntelliJ either community or ultimate should work. Use the latest one available.
 * Local clone of the main repo from https://github.com/davetcc/tcMenu
 * If you want to build the JavaAPI via maven you will need the GPG tool installed


### PR DESCRIPTION
This PR updates project dependencies in the pom files:
- It unifies the way how JavaFX is included
- JDK and JavaFX versions are defined on the top of the file

With these changes, IntelliJ IDEA sets up the project with correct library versions.

Notes:
- Even though the Liberica SDK is used by default, JavaFX was not picked up by IDEA. I had to enable JavaFX in the pom files. While at it, I also changed JDK to OpenJDK 20.
- IDEA was not able to properly pick up changes made in the pom files. It started working after I hit File | Invalidate cache and/or modified the module dependencies in File | Project Structure.
- You may consider including these notes in your documentation if you wish.